### PR TITLE
Add CSP and security headers

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -19,7 +19,7 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
 
     #CSP Header
-    add_header Content-Security-Policy "default-src 'self' ; script-src 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline';connect-src 'self' https://time.decred.org:49152/; manifest-src 'self'; object-src 'none';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://time.decred.org:49152/; manifest-src 'self'; object-src 'none';" always;
 
     location / {
         root   /usr/share/nginx/html;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -15,9 +15,11 @@ server {
     #Security Headers
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "same-origin" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-XSS-Protection "1; mode=block" always;
 
     #CSP Header
-    #add_header Content-Security-Policy "" always;
+    add_header Content-Security-Policy "default-src 'self' ; script-src 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline';connect-src 'self' https://time.decred.org:49152/; manifest-src 'self'; object-src 'none';" always;
 
     location / {
         root   /usr/share/nginx/html;


### PR DESCRIPTION
Fixes #82 

Added X-frame options and Xss protection.

Adds CSP 
style-src has 'unsafe-inline' this is not optimal and should be fixed when possible. (Google CSP evaluator **does not** penalize for this) https://csp-evaluator.withgoogle.com/ 

