### PR TITLE
Show all status tag content 

### DIFF
--- a/src/components/Results/Results.jsx
+++ b/src/components/Results/Results.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { Spinner, StatusTag } from "pi-ui";
 import { withRouter } from "react-router-dom";
 import ResultCard from "src/components/ResultCard";
@@ -11,15 +11,19 @@ const Results = ({ location }) => {
 
   if (error) throw error;
 
-  const getStatusTag = digest => {
+  const getStatusTag = useCallback(digest => {
+    function renderStatusTag(text, type) {
+      return <StatusTag text={text} type={type} className={styles.resultTag} />;
+    }
+
     if (isDigestAnchored(digest)) {
-      return <StatusTag text="Anchored" type="greenCheck" />;
+      return renderStatusTag("Anchored", "greenCheck");
     }
     if (isDigestAnchorPending(digest)) {
-      return <StatusTag text="Pending" type="bluePending" />;
+      return renderStatusTag("Pending", "bluePending");
     }
-    return <StatusTag text="Not Anchored" type="orangeNegativeCircled" />;
-  };
+    return renderStatusTag("Not Anchored", "orangeNegativeCircled");
+  }, []);
 
   return loading && !error ? (
     <div className={styles.spinner}>

--- a/src/components/Results/Results.module.css
+++ b/src/components/Results/Results.module.css
@@ -3,3 +3,7 @@
     justify-content: center;
     margin-top: 80px;
 }   
+
+.resultTag > span {
+    text-overflow: unset;
+}


### PR DESCRIPTION
Before:
![Screenshot 2020-04-26 at 12 56 41](https://user-images.githubusercontent.com/14864439/80305756-28b9f400-87bf-11ea-9084-f0c9a2a755ed.png)
Now:
![Screenshot 2020-04-26 at 12 56 51](https://user-images.githubusercontent.com/14864439/80305754-26f03080-87bf-11ea-9394-9f4aee2f37f9.png)

